### PR TITLE
feat: assemble dataframes with genomic and phenotypic information

### DIFF
--- a/dnadoh/assemble.py
+++ b/dnadoh/assemble.py
@@ -15,12 +15,12 @@ def read_combined(stem):
     variants = _read_genomes(stem, phenotypes)
     variants = variants.rename(columns={"base": "alternate"})
     variants["reference"] = variants.apply(
-        lambda x: reference["genome"][x["loc"]-1], axis=1)
+        lambda x: reference["genome"][x["location"] - 1], axis=1
+    )
     # re-arrange columns as convention is for reference to come before alternate
-    new_cols = ["loc", "reference", "alternate", "pid"]
+    new_cols = ["location", "reference", "alternate", "pid"]
     variants = variants[new_cols]
-    combined = phenotypes.set_index("pid").join(variants.set_index("pid"))
-    # combined = pd.merge(phenotypes, variants, on="pid", how="outer")
+    combined = pd.merge(phenotypes, variants, on="pid", how="outer")
     return combined
 
 
@@ -51,5 +51,6 @@ def _read_phenotypes(stem):
 
 if __name__ == "__main__":
     import sys
+
     combined = read_combined(sys.argv[1])
     print(combined)

--- a/dnadoh/assemble.py
+++ b/dnadoh/assemble.py
@@ -1,0 +1,60 @@
+"""Assemble data for analysis."""
+
+import csv
+import json
+
+import pandas as pd
+import util
+
+
+def read_data(stem):
+    """Assemble data from a set of files."""
+    reference = _read_reference_genome(stem)
+    phenotypes = _read_raw_phenotypes(stem)
+    variants, genomes = _read_genomes(stem, reference["genome"], phenotypes)
+    phenotypes["genome"] = genomes
+    return reference, variants, phenotypes
+
+
+def _read_genomes(stem, reference, raw_phenotypes):
+    """Read variant data and combine with reference to create genome."""
+    variants = None
+    genomes = []
+    for pid in raw_phenotypes["pid"]:
+        filename = util.filename_person(stem, pid)
+        temp = pd.read_csv(filename)
+        temp["pid"] = pid
+
+        if variants is None:
+            variants = temp
+        else:
+            variants = pd.concat([variants, temp])
+
+        genome = list(reference)
+        for _, row in temp.iterrows():
+            genome[row["loc"] - 1] = row["base"]
+        genomes.append("".join(genome))
+
+    return variants, genomes
+
+
+def _read_raw_phenotypes(stem):
+    """Return raw phenotype data as list of dictionaries."""
+    filename = util.filename_phenotypes(stem)
+    return pd.read_csv(filename)
+
+
+def _read_reference_genome(stem):
+    """Read reference genome (sequence plus mutation location(s))."""
+    filename = util.filename_reference_genome(stem)
+    with open(filename, "r") as reader:
+        return json.load(reader)
+
+
+if __name__ == "__main__":
+    import sys
+
+    reference, variants, phenotypes = read_data(sys.argv[1])
+    print(reference)
+    print(variants)
+    print(phenotypes)

--- a/dnadoh/synthesize.py
+++ b/dnadoh/synthesize.py
@@ -251,11 +251,11 @@ def _write_variants(options, genomes, people):
     for person in people:
         filename = util.filename_person(options.output_stem, person.pid)
         with open(filename, "w") as raw:
-            writer = csv.DictWriter(raw, fieldnames=["loc", "base"])
+            writer = csv.DictWriter(raw, fieldnames=["location", "base"])
             writer.writeheader()
             for i in range(len(genomes.reference)):
                 if person.genome[i] != genomes.reference[i]:
-                    writer.writerow({"loc": i + 1, "base": person.genome[i]})
+                    writer.writerow({"location": i + 1, "base": person.genome[i]})
 
 
 def _write_phenotypes(options, people):

--- a/dnadoh/util.py
+++ b/dnadoh/util.py
@@ -1,0 +1,61 @@
+"""Utilities."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+# Number of digits to use in person filenames.
+WIDTH = 6
+
+
+class Person(BaseModel):
+    """An individual person.
+
+    Values marked `Optional` are filled in one at a time.
+    """
+
+    # Person ID.
+    pid: int
+
+    # Genome.
+    genome: str
+
+    # Age in years.
+    age: Optional[int] = None
+
+    # Genetic sex {"F", "M", "O"}.
+    gsex: Optional[str] = None
+
+    # Weight in kg.
+    weight: Optional[float] = None
+
+
+def filename_overall(stem):
+    """Where to store overall summary."""
+    return f"{stem}-overall.csv"
+
+
+def filename_parameter(stem):
+    """Where to store parameters."""
+    return f"{stem}-parameters.json"
+
+
+def filename_person(stem, pid):
+    """Where to store information about a single person."""
+    pid_str = str(pid).zfill(WIDTH)
+    return f"{stem}-pid{pid_str}.csv"
+
+
+def filename_phenotypes(stem):
+    """Where to store phenotypic data for all people."""
+    return f"{stem}-phenotypes.csv"
+
+
+def filename_reference_genome(stem):
+    """Where to store reference genome."""
+    return f"{stem}-reference.json"
+
+
+def pid_width(length):
+    """Number of digits in personal information files' names."""
+    return max(2, len(str(length)))


### PR DESCRIPTION
Given a filename stem, `dnadoh/assemble.py` reads the set of files produced by synthesis to create:

1. a dictionary with the reference genome and the location(s) of significant mutations
2. a dataframe with (person ID, mutation location, base) for both significant and random mutations
3. a dataframe with (person ID, age, genetic sex, weight, and full genome)

Note: this PR builds on #2 and includes edits to that code - please only review `dnadoh/assemble.py` for now. We'll do a full review after #2 is merged into `main`.

```
# reference genome and mutation locations
{'genome': 'AAGTG', 'locations': [4]}
```

```
# mutation locations
   loc base  pid
0    1    G    1
0    3    T    2
1    5    A    2
0    3    A    3
```

```
# phenotype (and full genome, just because we have it)
   pid  age gsex  weight genome
0    1   28    M    90.9  GAGTG
1    2   42    F    75.0  AATTA
2    3   62    M    77.6  AAATG
```